### PR TITLE
Add instructions for testing on MacOS via Socat

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,21 @@ If you're using `tty0tty`, the tests will run at full speed. Real serial ports
 seem to take a fraction of a second to close and re-open. I added a gratuitous
 delay to each test to work around this. It likely can be much shorter.
 
+
+On MacOS, download and install [socat](http://www.dest-unreach.org/socat/). You can install it via Homebrew. Once you have it installed and ready to go, run the following command. You will need to change `<USERNAME>` to your current system username
+
+```sh
+sudo socat -d -d -d -d -lf /tmp/socat pty,link=/dev/dummy1,raw,echo=0,user=<USERNAME>,group=staff,link=/dev/dummy2,raw,echo=0,user=<USERNAME>,group=staff
+```
+
+Once that opens, in a separate terminal emulator, set the Circuits ENVars, and go about your testing
+
+```sh
+export CIRCUITS_UART_PORT1=/dev/dummy1
+export CIRCUITS_UART_PORT2=/dev/dummy2
+mix test
+```
+
 ## FAQ
 
 ### Do I have to use Nerves?


### PR DESCRIPTION
On MacOS, a virtual serial port can be created using the socat utility. This allows for running and passing of all the test cases, and aids in local development of serial devices as well.

I've added some instructions to the readme on how to set up said socat bridge