### PR TITLE
Add function to set controlling_process 

### DIFF
--- a/lib/circuits_uart.ex
+++ b/lib/circuits_uart.ex
@@ -323,6 +323,15 @@ defmodule Circuits.UART do
   def set_rts(pid, value) when is_boolean(value) do
     GenServer.call(pid, {:set_rts, value})
   end
+  
+  @doc """
+  Change the controlling process that
+  receives events from an active uart.
+  """
+  @spec controlling_process(GenServer.server(), pid) :: :ok | {:error, term}
+  def controlling_process(pid, controlling_process) when is_pid(controlling_process) do
+    GenServer.call(pid, {:controlling_process, controlling_process})
+  end
 
   # gen_server callbacks
   def init([]) do
@@ -490,6 +499,11 @@ defmodule Circuits.UART do
   def handle_call({:set_break, value}, _from, state) do
     response = call_port(state, :set_break, value)
     {:reply, response, state}
+  end
+  
+  def handle_call({:controlling_process, pid}, _from, state) do
+    new_state = %{state | controlling_process: pid}
+    {:reply, :ok, new_state}
   end
 
   def terminate(_reason, state) do

--- a/test/basic_uart_test.exs
+++ b/test/basic_uart_test.exs
@@ -420,6 +420,12 @@ defmodule BasicUARTTest do
       end
     end
   end
+  
+  test "call controlling_process", %{uart1: uart1} do
+    assert :ok = UART.open(uart1, UARTTest.port1(), active: false)
+    assert :ok = UART.controlling_process(uart1, self())
+    UART.close(uart1)
+  end
 
   test "changing config on open port" do
     # Implement me.


### PR DESCRIPTION
Add function to update controlling process, as already implemented on :gen_tcp and :gen_udp. I wasn't sure if you'd rather have this in configure, but having a separate function mimics the Erlang network libraries.

The reason this feature is useful is that it allows a user to move new/retry connection attempts into a separate process and pass the uart back to the main process (which is busy doing time-sensitive-rather-not-be-blocked-stuff) when it's ready.

I created a basic smoke test for calling the function but I have been unable to run the unit tests after following the OS X socat instructions (the devices just don't seem to be created in /dev, and yes I changed the user name).

Cheers,
Robin