### PR TITLE
Allow arbitrary data to be framed and sent

### DIFF
--- a/lib/circuits_uart.ex
+++ b/lib/circuits_uart.ex
@@ -247,7 +247,7 @@ defmodule Circuits.UART do
 
     * `:ebadf` - the UART is closed
   """
-  @spec write(GenServer.server(), iodata(), non_neg_integer()) :: :ok | {:error, term}
+  @spec write(GenServer.server(), any(), non_neg_integer()) :: :ok | {:error, term}
   def write(pid, data, timeout \\ 5000) do
     GenServer.call(pid, {:write, data, timeout}, genserver_timeout(timeout))
   end
@@ -443,10 +443,8 @@ defmodule Circuits.UART do
   end
 
   def handle_call({:write, data, timeout}, _from, state) do
-    bin_data = IO.iodata_to_binary(data)
-
     {:ok, framed_data, new_framing_state} =
-      apply(state.framing, :add_framing, [bin_data, state.framing_state])
+      apply(state.framing, :add_framing, [data, state.framing_state])
 
     response = call_port(state, :write, {framed_data, timeout}, port_timeout(timeout))
     new_state = %{state | framing_state: new_framing_state}


### PR DESCRIPTION
This is useful for complex framing cases, like, for example, EnOcean Serial Protocol 3 (ESP3) - https://www.enocean.com/esp3/, which has 2 checksums in the frame. It is more convenient to represent an application message as a tuple or structure than a binary or iolist, since unframing resulted in a broken-down message and vice versa.