### PR TITLE
Reduce Makefile/gcc prints to clean build output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,4 +124,5 @@ jobs:
       - run: mix compile
       - run: mix docs
       - run: mix format --check-formatted
+      - run: mix deps.unlock --check-unused
       - run: mix hex.build

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,5 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.1.0", "c5aab0d6e71e5522e77beff7ba9e08f8e02bad90dfbeffae60eaf0cb47e29488", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "07ea8e49c45f15264ebe6d5b93799d4dd56a44036cf42d0ad9c960bc266c0b9a"},
-  "earmark": {:hex, :earmark, "1.4.9", "837e4c1c5302b3135e9955f2bbf52c6c52e950c383983942b68b03909356c0d9", [:mix], [{:earmark_parser, ">= 1.4.9", [hex: :earmark_parser, repo: "hexpm", optional: false]}], "hexpm", "0d72df7d13a3dc8422882bed5263fdec5a773f56f7baeb02379361cb9e5b0d8e"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.13", "0c98163e7d04a15feb62000e1a891489feb29f3d10cb57d4f845c405852bbef8", [:mix], [], "hexpm", "d602c26af3a0af43d2f2645613f65841657ad6efc9f0e361c3b6c06b578214ba"},
   "elixir_make": {:hex, :elixir_make, "0.6.2", "7dffacd77dec4c37b39af867cedaabb0b59f6a871f89722c25b28fcd4bd70530", [:mix], [], "hexpm", "03e49eadda22526a7e5279d53321d1cced6552f344ba4e03e619063de75348d9"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,8 +7,7 @@
 #
 # Variables to override:
 #
-# BUILD         where to store intermediate files (defaults to src directory)
-# PREFIX        path to the installation direction (defaults to ./priv)
+# MIX_APP_PATH  path to the build directory
 #
 # CC            C compiler
 # CROSSCOMPILE	crosscompiler prefix, if any
@@ -18,7 +17,6 @@
 # ERL_EI_LIBDIR path to libei.a (Required for crosscompile)
 # LDFLAGS	linker flags for linking all binaries
 # ERL_LDFLAGS	additional linker flags for projects referencing Erlang libraries
-# MIX_APP_PATH  path to the build directory
 
 PREFIX = $(MIX_APP_PATH)/priv
 BUILD  = $(MIX_APP_PATH)/obj

--- a/src/Makefile
+++ b/src/Makefile
@@ -105,9 +105,11 @@ install: $(PREFIX) $(BUILD) $(BUILD)/ei_copy $(PORTEXE)
 $(OBJ): $(HEADERS) src/Makefile
 
 $(BUILD)/%.o: src/%.c
+	@echo " CC $(notdir $@)"
 	$(CC) -c $(ERL_CFLAGS) $(CFLAGS) -o $@ $<
 
 $(PORTEXE): $(OBJ)
+	@echo " LD $(notdir $@)"
 	$(CC) $^ $(ERL_LDFLAGS) $(LDFLAGS) -o $@
 
 ifeq ($(OS),Windows_NT)
@@ -125,3 +127,6 @@ clean:
 endif
 
 .PHONY: all clean install
+
+# Don't echo commands unless the caller exports "V=1"
+${V}.SILENT:


### PR DESCRIPTION
The gcc commandlines and other prints can be useful, but most of the
time they are overwhelming especially for non-C programmers. This
simplifies the prints.

To re-enable, set `V=1` like is common with many Makefile/C projects.
For example `V=1 make`, `V=1 mix compile`, etc.
