### PR TITLE
Add find_pid/1

### DIFF
--- a/lib/circuits_uart.ex
+++ b/lib/circuits_uart.ex
@@ -93,6 +93,14 @@ defmodule Circuits.UART do
     |> Enum.map(&circuits_uart_info/1)
   end
 
+  @spec find_pid(binary) :: pid() | nil
+  def find_pid(port_name) do
+    case find_pids() do
+      [{pid, ^port_name}] -> pid
+      _ -> nil
+    end
+  end
+
   defp is_circuits_uart_process(pid) do
     {:dictionary, dictionary} = Process.info(pid, :dictionary)
     Keyword.get(dictionary, :"$initial_call") == {Circuits.UART, :init, 1}


### PR DESCRIPTION
This is an idea for minor enhancement.

I thought it would be nice to have a function to find pid by port name since we most likely know which port we are using. We can achieve it just by doing pattern-matching against the result of `find_pids/0`. What do you think?