### PR TITLE
Fix typespec for read/2

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,4 +2,4 @@
 
 Please refer to the [Nerves Project Code of Conduct], which applies to all `elixir-circuits` repositories.
 
-[Nerves Project Code of Conduct]: https://github.com/elixir-circuits/circuits_uart/blob/master/CODE_OF_CONDUCT.md
+[Nerves Project Code of Conduct]: https://github.com/elixir-circuits/circuits_uart/blob/main/CODE_OF_CONDUCT.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Please refer to the [Nerves Project Contributing Guide], which applies to all `elixir-circuits` repositories.
 
-[Nerves Project Contributing Guide]: https://github.com/elixir-circuits/circuits_uart/blob/master/CONTRIBUTING.md
+[Nerves Project Contributing Guide]: https://github.com/nerves-project/.github/blob/main/CONTRIBUTING.md

--- a/lib/circuits_uart.ex
+++ b/lib/circuits_uart.ex
@@ -296,7 +296,8 @@ defmodule Circuits.UART do
   * `:ebadf` - the UART is closed
   * `:einval` - the UART is in active mode
   """
-  @spec read(GenServer.server(), non_neg_integer()) :: {:ok, binary} | {:error, File.posix()}
+  @spec read(GenServer.server(), non_neg_integer()) ::
+          {:ok, binary} | {:ok, {:partial, binary}} | {:error, File.posix()}
   def read(pid, timeout \\ 5000) do
     GenServer.call(pid, {:read, timeout}, genserver_timeout(timeout))
   end


### PR DESCRIPTION
Added {:ok, {:partial, binary}} to the typespec of the read function.

Fixed links to Code of Conduct and Nerves Project Contributing Guide.

