### PR TITLE
Fixed Code of Conduct link.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,4 +2,4 @@
 
 Please refer to the [Nerves Project Code of Conduct], which applies to all `elixir-circuits` repositories.
 
-[Nerves Project Code of Conduct]: https://github.com/elixir-circuits/circuits_uart/blob/main/CODE_OF_CONDUCT.md
+[Nerves Project Code of Conduct]: https://github.com/nerves-project/.github/blob/main/CODE_OF_CONDUCT.md


### PR DESCRIPTION
This link points to the correct Nerves Project Code of Conduct.
