### PR TITLE
fix continue_in_progress_write() pointer arithmetic error

### DIFF
--- a/src/uart_comm_unix.c
+++ b/src/uart_comm_unix.c
@@ -677,7 +677,7 @@ static void continue_in_progress_write(struct uart *port)
     size_t to_write = port->write_len - port->write_offset;
     ssize_t written;
     do {
-        written = write(port->fd, &port->write_data + port->write_offset, to_write);
+        written = write(port->fd, (const uint8_t *)port->write_data + port->write_offset, to_write);
         debug("continue_in_progress_write: wrote %d/%d, errno=%d (%s)", (int) written, (int) to_write, errno, strerror(errno));
     } while (written < 0 && errno == EINTR);
 


### PR DESCRIPTION
Erroneous use of the location of the pointer, rather than the pointer itself

Previously, any follow on write in continue_in_progress_write() would fail with various errors, and likely include random bursts of 0s in the data stream

This will close several other long open issues. 