### PR TITLE
bump max trasfer size to true 32KB

### DIFF
--- a/src/erlcmd.h
+++ b/src/erlcmd.h
@@ -14,7 +14,7 @@
 /*
  * Erlang request/response processing
  */
-#define ERLCMD_BUF_SIZE 16384 // Large size is to support large UART writes
+#define ERLCMD_BUF_SIZE 32768 + 30 // Large size is to support large UART writes
 struct erlcmd
 {
     char buffer[ERLCMD_BUF_SIZE];


### PR DESCRIPTION
We need a little extra space in our buffer for the command overhead 
Allocate this plus space for 32KB of data giving us a true 32KB transfer

Previously you couldn't quite transmit a 16KB buffer, which is annoying because it's a useful power of 2. With this you can transmit buffers sized to power of 2 up to 32768 bytes. I think this is quite helpful for many use cases